### PR TITLE
gerrit.service.j2: fixing pid location

### DIFF
--- a/templates/etc/systemd/system/gerrit.service.j2
+++ b/templates/etc/systemd/system/gerrit.service.j2
@@ -11,7 +11,7 @@ StandardError=syslog
 SyslogIdentifier=gerrit
 ExecStart={{ gerrit_site_dir }}/bin/gerrit.sh start
 ExecStop={{ gerrit_site_dir }}/bin/gerrit.sh stop
-PIDFile=/var/gerrit/logs/gerrit.pid
+PIDFile={{ gerrit_site_dir }}/logs/gerrit.pid
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
PID file is on {{ gerrit_site_dir }}/logs/gerrit.pid